### PR TITLE
Throw exception if nonce is missing

### DIFF
--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -245,6 +245,9 @@ class LTI_Message_Launch {
     }
 
     private function validate_nonce() {
+        if (!isset($this->jwt['body']['nonce'])) {
+            throw new LTI_Exception("Missing Nonce");
+        }
         if (!$this->cache->check_nonce($this->jwt['body']['nonce'])) {
             //throw new LTI_Exception("Invalid Nonce");
         }


### PR DESCRIPTION
This will prevent an error occurring when doing LTI 1.3 certification on a bad launch test case.